### PR TITLE
feat(focusUtils): A simple focus map

### DIFF
--- a/components/UIcomponents/baseUIComponent/baseUIComponent.xml
+++ b/components/UIcomponents/baseUIComponent/baseUIComponent.xml
@@ -2,7 +2,9 @@
 <component name="baseUIComponent" extends="Group">
 
   <script type="text/brightscript" uri="pkg:/components/Utils/sceneUtils.brs" />
+  <script type="text/brightscript" uri="pkg:/components/Utils/focusUtils.brs" />
   <script type="text/brightscript" uri="pkg:/components/Utils/buttonUtils.brs" />
+  <script type="text/brightscript" uri="pkg:/components/Utils/registryClient.brs" />
   <script type="text/brightscript" uri="pkg:/source/Utils/generalUtils.brs" />
   <script type="text/brightscript" uri="pkg:/source/constants.brs" />
 

--- a/components/Utils/focusUtils.brs
+++ b/components/Utils/focusUtils.brs
@@ -13,15 +13,6 @@ function applyFocus(obj as Object, focusState = true as Boolean, log = "" as Str
   end if
 end function
 
-
-' Creates a focus map for all components
-' @param - Object - An array of focusable components on the view
-' @return - Associative array - Focus Map Object'
-' Sample focus map : { comp: { up: invalid, down: invalud, left: invalid, right: 'componentname' } }'
-function createFocusMap( components as Object ) as Object
-
-end function
-
 ' Set's the focus on the corresponding item
 ' @param - String Button key press
 ' @Param - Object focusMap for that view
@@ -51,5 +42,112 @@ function componentFocusHandler( key, focusMap, currentFocusedComponent ) as Bool
   end if
 
   return focusState
+
+end function
+
+' Creates a focus map for all components
+' @param - Object - An array of focusable components on the view
+' @return - Associative array - Focus Map Object'
+' Sample focus map : { comp: { up: invalid, down: invalud, left: invalid, right: 'componentname' } }'
+function createFocusMap( components as Object ) as Object
+
+  focusMap = { }
+
+  for i = 0 to ( components.count() - 1 )
+    component = components[ i ]
+
+    componentMap = CreateComponentMap( component, components )
+    focusMap[ component.id ] = componentMap
+  end for
+
+  return focusMap
+end function
+
+' Creates a single focus map for the given component
+' @param Component
+' @param Array Components
+function CreateComponentMap( component, components )
+
+  map = { "up": invalid, "down": invalid, "left": invalid, "right": invalid }
+
+  currentMids = getMidpointCoords(component)
+
+  for i = 0 to ( components.Count() - 1 )
+
+    otherComponent = components[ i ]
+    if ( (component.id <> otherComponent.id) and (otherComponent.focusable) )
+      otherMids = getMidpointCoords(otherComponent)
+
+      if ( otherMids.x > currentMids.x )
+        compareComponentCoords( otherComponent, map, "right", false, components )
+      else if ( otherMids.x < currentMids.x )
+        compareComponentCoords( otherComponent, map, "left", true, components )
+      end if
+
+      if ( otherMids.y > currentMids.y )
+        compareComponentCoords( otherComponent, map, "down", false, components )
+      else if ( otherMids.y < currentMids.y )
+        compareComponentCoords( otherComponent, map, "up", true, components )
+      end if
+
+    end if
+
+  end for
+
+  return map
+
+end function
+
+' Compares componets and sets it
+' @Param node in inspection
+' @param map component focusMap
+' @param string direction string
+' @param bool sign to state if less or greater than comparisson
+function compareComponentCoords( otherComponent as Object, map as Object, direction as String, sign as Boolean, components as Object )
+
+  otherMids = getMidpointCoords(otherComponent)
+
+   position = "x"
+  if ( direction = "up" OR direction = "down" )
+    position = "y"
+  end if
+
+  if ( not isValid(map[direction]) )
+    map[direction] = otherComponent.id
+  else
+    existingCmpMids = getMidpointCoords( findComponent( map[direction], components ) )
+
+    if ( sign and ( otherMids[position] > existingCmpMids[position] ) )
+      map[direction] = otherComponent.id
+    else if ( otherMids[position] < existingCmpMids[position] )
+      map[direction] = otherComponent.id
+    end if
+
+  end if
+
+end function
+
+' Returns the midpoint of the component
+' @param node
+function getMidpointCoords( component )
+
+  bounds = component.boundingRect()
+
+  midx = bounds.x + ( bounds.width/2 )
+  midy = bounds.y + ( bounds.height/2 )
+
+  return { x: midx, y: midy }
+
+end function
+
+function findComponent( name, components )
+
+  for i = 0 to components.Count() - 1
+
+    cmp = components[ i ]
+    if ( cmp.id = name ) return cmp
+  end for
+
+  return invalid
 
 end function

--- a/components/tests/UIComponents/baseUIComponent/Test__BaseUIComponent.xml
+++ b/components/tests/UIComponents/baseUIComponent/Test__BaseUIComponent.xml
@@ -1,0 +1,11 @@
+<component name="Test__BaseUIComponent" extends="baseUIComponent">
+
+	<interface>
+		<function name="TestFramework__RunNodeTests"/>
+	</interface>
+
+	<script type="text/brightscript" uri="pkg:/source/testFramework/UnitTestFramework.brs"/>
+
+	<script type="text/brightscript" uri="pkg:/components/tests/UIComponents/baseUIComponent/Test__BaseUIComponent__TestSuite.brs"/>
+
+</component>

--- a/components/tests/UIComponents/baseUIComponent/Test__BaseUIComponent__TestSuite.brs
+++ b/components/tests/UIComponents/baseUIComponent/Test__BaseUIComponent__TestSuite.brs
@@ -1,0 +1,57 @@
+
+function TestSuite__BaseUIComponent()
+
+  this = BaseTestSuite()
+
+  this.name = "BaseUIComponent"
+
+  ' Set up and Tear down methods'
+  this.SetUp = TestSuite__BaseUIComponent__SetUp
+  this.TearDown = TestSuite__BaseUIComponent__TearDown
+
+  ' Test for focus map'
+  this.addTest("Focus Map Test", TestCase__BaseUIComponent_CreateFocusMap )
+
+  return this
+end function
+
+
+function TestSuite__BaseUIComponent__SetUp()
+
+  m.scene = GetScene()
+
+  m.container = CreateObject("roSGNode", "Group")
+  m.container.id = "testContainer"
+  for i=0 to 2
+    rect = CreateObject("roSGNode", "Rectangle")
+    rect.translation = [10*i, 0]
+    rect.width = 5
+    rect.height = 5
+    rect.id = "testRect" + i.toStr()
+    rect.focusable = true
+    m.container.appendChild(rect)
+  end for
+  m.scene.appendChild(m.container)
+  m.focusMap = {
+    "testRect0":{left:invalid, right:"testRect1", up:invalid, down:invalid},
+    "testRect1":{left:"testRect0", right:"testRect2", up:invalid, down:invalid},
+    "testRect2":{left:"testRect1", right:invalid, up:invalid, down:invalid},
+  }
+
+end function
+
+function TestSuite__BaseUIComponent__TearDown()
+  m.scene.removeChild(m.container)
+  m.scene = invalid
+  m.focusMap = invalid
+  m.container = invalid
+end function
+
+'********** TEST CASES ***********'
+
+function TestCase__BaseUIComponent_CreateFocusMap()
+
+  focusMap = createFocusMap(m.container.getChildren(3,0))
+  return m.assertEqual(focusMap, m.focusMap)
+
+end function


### PR DESCRIPTION
A simple focus map that calculates element positions based on mid-pt
co-ordinates.

It assumes that higher level component based focus exists and it is
meant to be used within a complex component that needs it's focus map
compuited on demand.

One should refrain from using this frequently as it takes a performance
hit.

close