### PR TITLE
Fix(ScrollView and Dialog): Scrollview and Dialog

### DIFF
--- a/components/UIcomponents/scrollView/scrollView.brs
+++ b/components/UIcomponents/scrollView/scrollView.brs
@@ -25,8 +25,8 @@ function onFocus(event as Object)
   if ( m.top.hasFocus() )
 
     if ( m.top.children.count() > 0 )
-      firstChild = m.top.children[0]
-      setFocusOnChild( firstChild, " onFocus() - " )
+      firstChild = m.top.children[ m.top.currentIndex ]
+      if ( isValid( firstChild ) ) then setFocusOnChild( firstChild, " onFocus() - " )
     end if
 
   end if

--- a/components/Utils/sceneUtils.brs
+++ b/components/Utils/sceneUtils.brs
@@ -34,7 +34,8 @@ function openDialog( dialog as Object, currentFocusItem as Object, scene = GetSc
     dialog.translation = [ Abs(( 1920 - dialogBounds.width ) / 2), Abs((1080 - dialogBounds.height) / 2) ]
 
     dialog.parentFocusItem = currentFocusItem
-    applyFocus( dialog, true, "setDialog() - sceneUtils.brs" )
+    dialog.setFocus( true )
+    print "Setting focus on Dialog " + dialog.id + " openDialog() - sceneUtils.brs "
   end if
 
 end function


### PR DESCRIPTION
Dialog was stealing focus and resetting focus back to the page
incorrectcly.

Scrollview was not setting focus on the right item when focus is back

Close()