### PR TITLE
Fix(Focus): scope of current focus item

### DIFF
--- a/components/BaseScene/BaseScene.xml
+++ b/components/BaseScene/BaseScene.xml
@@ -9,6 +9,7 @@
   <script type="text/brightscript" uri="pkg:/source/Factories/controllerFactory.brs" />
 
   <interface>
+    <field id="currentFocusItem" type="node" />
     <field id="currentController" type="node" />
     <field id="loadController" type="assocarray" alwaysNotify="true" onchange="onLoad" />
     <field id="unloadController" type="boolean" alwaysNotify="true" onchange="onUnLoad" />

--- a/components/Utils/focusUtils.brs
+++ b/components/Utils/focusUtils.brs
@@ -6,9 +6,10 @@
 function applyFocus(obj as Object, focusState = true as Boolean, log = "" as String )
 
   if (isValid(obj))
+    scene = getScene()
 
     obj.setFocus(focusState)
-    m.currentFocusItem = obj
+    scene.currentFocusItem = obj
     print " Setting Focus on component ID " + obj.id + " Log : " + log
   end if
 end function


### PR DESCRIPTION
The scope of current focus item is no longer restricted to be known only within a controller component. It can now be known anywhere within the active scene.

Close()